### PR TITLE
Made pep8 compatible, also found a small bug

### DIFF
--- a/alto_ocr_confidence.py
+++ b/alto_ocr_confidence.py
@@ -5,20 +5,32 @@ import os
 import sys
 import xml.etree.cElementTree as ET
 
-namespace = {'alto-1': 'http://schema.ccs-gmbh.com/ALTO', 'alto-2': 'http://www.loc.gov/standards/alto/ns-v2#', 'alto-3': 'http://www.loc.gov/standards/alto/ns-v3#'}
+namespace = {'alto-1': 'http://schema.ccs-gmbh.com/ALTO',
+             'alto-2': 'http://www.loc.gov/standards/alto/ns-v2#',
+             'alto-3': 'http://www.loc.gov/standards/alto/ns-v3#'}
 
-for root, dirs, files in os.walk(sys.argv[1]):
-	for file in files:
-		if file.endswith('.xml') or file.endswith('.alto'):
-			fname = open(os.path.join(root, file))
-			for f in fname:
-				tree = ET.parse(fname)
-				score = 0
-				count = 0
-				for elem in tree.iterfind('.//alto-2:String', namespace): # make sure the correct namespace is set
-					wc = elem.attrib.get('WC')
-					score += float(wc)
-					count += 1
-				confidence = score/count
-				result = round(100 * (confidence), 2)
-				print('Filename: %s, Confidence: %s' % (file, result))
+
+def parse_alto(fh, filename):
+    tree = ET.parse(fh)
+    score = 0
+    count = 0
+    for elem in tree.iterfind('.//alto-2:String', namespace):
+            wc = elem.attrib.get('WC')
+            score += float(wc)
+            count += 1
+    confidence = score / count
+    result = round(100 * confidence, 2)
+    print('Filename: %s, Confidence: %s' % (filename, result))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python %s <inputdir>" % os.path.basename(__file__))
+        sys.exit(-1)
+
+    for root, dirs, files in os.walk(sys.argv[1]):
+        for filename in files:
+            if filename.endswith('.xml') or filename.endswith('.alto'):
+                fh = open(os.path.join(root, filename))
+                for f in fh:  # Dunno what to do with this?
+                    parse_alto(fh, filename)
+                fh.close()


### PR DESCRIPTION
did a quick review,

some quick remarks,
'file' is a reserved keyword, so better not use that in the for file in files loop,
rather use filename.
https://docs.python.org/2/library/functions.html#file

open(os.path.join(root, file)) gives you a filehandler, so fh= instead of fname= would be more appropriate.

and now the part that puzzels me or is a bug:

the : for f in fname: loop

Yet 'f' is never used, the program keeps using fname to parse?!
